### PR TITLE
Add HACS validation GitHub Action

### DIFF
--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -1,0 +1,17 @@
+name: HACS Validation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  hacs:
+    name: Validate with HACS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: HACS Action
+        uses: hacs/action@22.5.0


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs the HACS validation action on pushes and pull requests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fba94baab48326b2d302c05e4eb08e