### PR TITLE
Add plugin category to HACS validation workflow

### DIFF
--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -15,3 +15,5 @@ jobs:
         uses: actions/checkout@v4
       - name: HACS Action
         uses: hacs/action@22.5.0
+        with:
+          category: plugin


### PR DESCRIPTION
## Summary
- configure the HACS GitHub Action to run with the plugin category

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbaad953608326ba62d824db9d1044