### PR TITLE
Fix temperature slider: color_temp_kelvin instead of deprecated color_temp

### DIFF
--- a/hass-spatial-lights-card.js
+++ b/hass-spatial-lights-card.js
@@ -4611,9 +4611,8 @@ class SpatialLightColorCard extends HTMLElement {
       : (this._config.default_entity ? [this._config.default_entity] : []);
     if (controlled.length === 0 || !Number.isFinite(kelvin)) return;
 
-    const mireds = Math.round(1000000 / kelvin);
     controlled.forEach(entity_id => {
-      this._hass.callService('light', 'turn_on', { entity_id, color_temp: mireds });
+      this._hass.callService('light', 'turn_on', { entity_id, color_temp_kelvin: kelvin });
     });
 
     // Update slider to reflect the new temp
@@ -4705,9 +4704,8 @@ class SpatialLightColorCard extends HTMLElement {
       : (this._config.default_entity ? [this._config.default_entity] : []);
     if (controlled.length === 0) { this._pendingTemperature = null; return; }
 
-    const mireds = Math.round(1000000 / this._pendingTemperature);
     controlled.forEach(entity_id => {
-      this._hass.callService('light', 'turn_on', { entity_id, color_temp: mireds });
+      this._hass.callService('light', 'turn_on', { entity_id, color_temp_kelvin: this._pendingTemperature });
     });
     this._pendingTemperature = null;
   }


### PR DESCRIPTION
Home Assistant 2026.1 removed the deprecated `color_temp` (mireds) parameter from the light.turn_on service. Replace with `color_temp_kelvin` which accepts Kelvin values directly, eliminating the mireds conversion